### PR TITLE
Update script fixes

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -29,7 +29,7 @@ abort_merge()
 }
 
 # get current branch
-local_branch=$(git branch --show-current)
+local_branch=$(git rev-parse --abbrev-ref HEAD)
 
 # look for a remote tracking branch
 remote_branch=$(git config --get branch.${local_branch}.merge || true)

--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -34,16 +34,9 @@ local_branch=$(git rev-parse --abbrev-ref HEAD)
 # look for a remote tracking branch
 remote_branch=$(git config --get branch.${local_branch}.merge || true)
 if [ -z "${remote_branch}" ]; then
-    # if local_branch is "default" and pwd is a repo checkout:
-    # the remote branch can default to master, otherwise abort
-    local_dir=$(pwd)
-    if [ "${local_branch}" = "default" ] && [ -z "${local_dir##*".repo/manifests"*}" ]; then
-        remote_branch="refs/heads/master"
-    else
-        echo "fatal: The current branch has no upstream branch."
-        echo "To set the upstream tracking branch, use: git branch -u <remote>/<branch>"
-        exit 1
-    fi
+    echo "fatal: The current branch has no upstream branch."
+    echo "To set the upstream tracking branch, use: git branch -u <remote>/<branch>"
+    exit 1
 fi
 
 # fetch tags from upstream

--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -52,7 +52,7 @@ git fetch --tags --quiet ${foundries_manifest}
 # if no tag parameter was supplied use latest upstream tag
 if [ -z "${latest}" ]; then
     # assign last upstream tag to latest
-    latest=$(git tag --list --points-at FETCH_HEAD)
+    latest=$(git describe --tags --abbrev=0)
 fi
 
 # check to see if last upstream tag is already included in HEAD (if so exit)

--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -1,0 +1,79 @@
+#!/bin/sh
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2019 Foundries.io
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# set defaults
+foundries_manifest="https://github.com/foundriesio/lmp-manifest"
+latest=${1}
+
+# break on errors
+set -e
+
+abort_merge()
+{
+    errno=${1}
+    git merge --abort || true
+    echo ""
+    echo "Unable to perform automatic update.  Restoring previous state."
+
+    if [ "${errno}" != "128" ]; then
+        echo ""
+        echo "One of these last few commits is probably causing a conflict:"
+        git log --no-merges --max-count=10 --format=oneline FETCH_HEAD..HEAD
+    fi
+    exit 1
+}
+
+# get current branch
+local_branch=$(git branch --show-current)
+
+# look for a remote tracking branch
+remote_branch=$(git config --get branch.${local_branch}.merge || true)
+if [ -z "${remote_branch}" ]; then
+    # if local_branch is "default" and pwd is a repo checkout:
+    # the remote branch can default to master, otherwise abort
+    local_dir=$(pwd)
+    if [ "${local_branch}" = "default" ] && [ -z "${local_dir##*".repo/manifests"*}" ]; then
+        remote_branch="refs/heads/master"
+    else
+        echo "fatal: The current branch has no upstream branch."
+        echo "To set the upstream tracking branch, use: git branch -u <remote>/<branch>"
+        exit 1
+    fi
+fi
+
+# fetch tags from upstream
+git fetch --tags --quiet ${foundries_manifest}
+
+# if no tag parameter was supplied use latest upstream tag
+if [ -z "${latest}" ]; then
+    # assign last upstream tag to latest
+    latest=$(git tag --list --points-at FETCH_HEAD)
+fi
+
+# check to see if last upstream tag is already included in HEAD (if so exit)
+errno=0
+git merge-base --is-ancestor ${latest} HEAD || errno=$?
+# found tag as ancestor, no updates
+if [ "${errno}" -eq 0 ]; then
+    echo "No new releases found upstream"
+    exit 0
+# unhandled error (invalid object name)
+elif [ "${errno}" -gt 1 ]; then
+    exit 1
+fi
+
+echo "New upstream release(s) have been found."
+echo "Merging local code with upstream release: ${latest}"
+
+# merge to the last upstream tag
+git merge --no-edit -m "update-manifest: merge LmP ${latest}" ${latest} || abort_merge $?
+
+echo ""
+echo "Automatic update successful!"
+
+git push origin HEAD:${remote_branch} && git push --tags origin


### PR DESCRIPTION
This is a series of fixes to migrate and update the update-factory-manifest script:
- import current version of the script from lmp-manifest
- make git command which looks up the current branch compatible with older git versions
- bugfix to finding the latest tag upstream
- dont assume master branch just exit with warning message