### PR TITLE
update-factory-manifest: use describe on fetch head

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -45,7 +45,7 @@ git fetch --tags --quiet ${foundries_manifest}
 # if no tag parameter was supplied use latest upstream tag
 if [ -z "${latest}" ]; then
     # assign last upstream tag to latest
-    latest=$(git describe --tags --abbrev=0)
+    latest=$(git describe --tags --abbrev=0 FETCH_HEAD)
 fi
 
 # check to see if last upstream tag is already included in HEAD (if so exit)


### PR DESCRIPTION
Use describe on fetch head (available after git fetch) as a way to find
the latest tag that is available on lmp-manifest upstream. Calling
describe without pointing out a reference makes it use what is head from
the running branch (one to be updated to).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>