### PR TITLE
security: imx_hab4: sign-file.sh update for CST 3.3.1

### DIFF
--- a/security/imx_hab4/sign-file.sh
+++ b/security/imx_hab4/sign-file.sh
@@ -156,6 +156,12 @@ fi
 if [ -n "${ENGINE}" ]
 then
     sed -i~ "s/^Engine =.*/Engine = ${ENGINE}/g" ${CSF_TEMPLATE}.csf-config
+    if [ "${ENGINE}" = "SW" ]
+    then
+        # Remove the unlock block, it is not needed for SW engine
+        awk '/^\[Unlock\]/, /^Feature/{next}{print $0}' ${CSF_TEMPLATE}.csf-config > ${CSF_TEMPLATE}.csf-config~
+        mv ${CSF_TEMPLATE}.csf-config~ ${CSF_TEMPLATE}.csf-config
+    fi
 fi
 
 # working file used for signature
@@ -259,6 +265,6 @@ fi
 
 # Cleanup config / mod SPL
 rm ${CSF_TEMPLATE}.csf-config
-rm ${CSF_TEMPLATE}.csf-config~
+rm -f ${CSF_TEMPLATE}.csf-config~
 rm ${WORK_FILE}_csf.bin
 rm ${WORK_FILE}.mod


### PR DESCRIPTION
The updated cst tools validates the Unlock block in the config
file. That means that the Unlock section should be removed for
an Engine of SW.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>