### PR TITLE
imx_hab4: sign-file: error on bad params

### DIFF
--- a/security/imx_hab4/sign-file.sh
+++ b/security/imx_hab4/sign-file.sh
@@ -67,9 +67,11 @@ parse_args()
         --srk-index)
             SRK_INDEX=${2}
             shift
+            shift
             ;;
         --engine)
             ENGINE=${2}
+            shift
             shift
             ;;
         -h)

--- a/security/imx_hab4/sign-file.sh
+++ b/security/imx_hab4/sign-file.sh
@@ -81,7 +81,8 @@ parse_args()
             shift
             ;;
         *)
-            shift
+            echo "Unknown param: '${1}'!"
+            exit 1
             ;;
         esac
     done


### PR DESCRIPTION
Currently, we allow badly formed parameters in the sign-file script.
This is definitely not desirable.  Let's instead generate an error
message and return an error code.

Example of badly formed parameter:
$ ./sign-file.sh --cst ./cst --enigne SW --spl SPL-test
Unknown param: '--enigne'!

Signed-off-by: Michael Scott <mike@foundries.io>