### PR TITLE
security: update gen_close scripts to error if close fails

### DIFF
--- a/security/imx6/gen_close.sh
+++ b/security/imx6/gen_close.sh
@@ -86,7 +86,7 @@ do
 done
 echo
 cat << EOF
-FB: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; fi
+FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
 FB: acmd reset
 
 FB: DONE

--- a/security/imx6ul/gen_close.bat
+++ b/security/imx6ul/gen_close.bat
@@ -89,7 +89,7 @@ echo.FB: ucmd setenv srk_5 0x!line:~46,2!!line:~44,2!!line:~42,2!!line:~40,2!
 echo.FB: ucmd setenv srk_6 0x!line:~54,2!!line:~52,2!!line:~50,2!!line:~48,2!
 echo.FB: ucmd setenv srk_7 0x!line:~62,2!!line:~60,2!!line:~58,2!!line:~56,2!
 echo.
-echo.FB: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; fi
+echo.FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
 echo.FB: acmd reset
 echo.
 echo.FB: DONE

--- a/security/imx6ul/gen_close.sh
+++ b/security/imx6ul/gen_close.sh
@@ -74,7 +74,7 @@ do
 done
 echo
 cat << EOF
-FB: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; fi
+FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
 FB: acmd reset
 
 FB: DONE

--- a/security/imx7ulpea-ucom/gen_close.sh
+++ b/security/imx7ulpea-ucom/gen_close.sh
@@ -76,7 +76,7 @@ do
     echo
 done
 cat << EOF
-FB: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; fi
+FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
 FB: acmd reset
 
 FB: DONE

--- a/security/imx8m/gen_close.sh
+++ b/security/imx8m/gen_close.sh
@@ -88,7 +88,7 @@ do
 done
 echo
 cat << EOF
-FB: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; fi
+FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
 FB: acmd reset
 
 FB: DONE


### PR DESCRIPTION
If the board fails to close the script was completing with no
failures. This will cause a timeout error making uuu exit with
an failure count and an error return to the shell.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>