### PR TITLE
security: imx8m: change SPL to imx-boot for gen scripts

### DIFF
--- a/security/imx8m/gen_close.sh
+++ b/security/imx8m/gen_close.sh
@@ -68,7 +68,7 @@ fi
 (cat << EOF
 uuu_version 1.2.39
 
-SDP: boot -f SPL-mfgtool.signed
+SDP: boot -f imx-boot-mfgtool.signed
 $TORADEX
 
 SDPU: delay 1000

--- a/security/imx8m/gen_fuse.sh
+++ b/security/imx8m/gen_fuse.sh
@@ -70,7 +70,7 @@ fi
 uuu_version 1.2.39
 $TORADEX
 
-SDP: boot -f SPL-mfgtool.signed
+SDP: boot -f imx-boot-mfgtool.signed
 
 SDPU: delay 1000
 SDPV: write -f u-boot-mfgtool.itb


### PR DESCRIPTION
imx8m uses imx-boot as SPL so change the name accordingly for the
gen scripts.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>