### PR TITLE
security: imx8m: general fixes

### DIFF
--- a/security/imx8m/gen_close.sh
+++ b/security/imx8m/gen_close.sh
@@ -71,9 +71,9 @@ uuu_version 1.2.39
 SDP: boot -f imx-boot-mfgtool.signed
 $TORADEX
 
-SDPU: delay 1000
+SDPV: delay 1000
 SDPV: write -f u-boot-mfgtool.itb
-SDPU: jump
+SDPV: jump
 
 FB: ucmd if mmc dev 0; then setenv fiohab_dev 0; else setenv fiohab_dev 1; fi;
 

--- a/security/imx8m/gen_close.sh
+++ b/security/imx8m/gen_close.sh
@@ -75,7 +75,7 @@ SDPV: delay 1000
 SDPV: write -f u-boot-mfgtool.itb
 SDPV: jump
 
-FB: ucmd if mmc dev 0; then setenv fiohab_dev 0; else setenv fiohab_dev 1; fi;
+FB: ucmd if mmc dev 2; then setenv fiohab_dev 2; else setenv fiohab_dev 1; fi;
 
 EOF
 HASH=($(hexdump -e '/4 "0x"' -e '/4 "%X""\n"' ${FUSEBIN}))

--- a/security/imx8m/gen_fuse.sh
+++ b/security/imx8m/gen_fuse.sh
@@ -72,9 +72,9 @@ $TORADEX
 
 SDP: boot -f imx-boot-mfgtool.signed
 
-SDPU: delay 1000
+SDPV: delay 1000
 SDPV: write -f u-boot-mfgtool.itb
-SDPU: jump
+SDPV: jump
 
 EOF
 HASH=($(hexdump -e '/4 "0x"' -e '/4 "%X""\n"' ${FUSEBIN}))


### PR DESCRIPTION
Using SDPU command makes the imx8mmevk board hang, so fix it to use SDPV commands.
Also emmc device for this board is at mmc dev 2, so use this as default on gen_close.uuu.