### PR TITLE
security: imx7ulp: fix SDP commands

### DIFF
--- a/security/imx7ulpea-ucom/gen_close.sh
+++ b/security/imx7ulpea-ucom/gen_close.sh
@@ -59,9 +59,9 @@ uuu_version 1.2.39
 
 SDP: boot -f SPL-mfgtool.signed
 
-SDPU: delay 1000
+SDPV: delay 1000
 SDPV: write -f u-boot-mfgtool.itb
-SDPU: jump
+SDPV: jump
 
 FB: ucmd if mmc dev 0; then setenv fiohab_dev 0; else setenv fiohab_dev 1; fi;
 

--- a/security/imx7ulpea-ucom/gen_fuse.sh
+++ b/security/imx7ulpea-ucom/gen_fuse.sh
@@ -60,9 +60,9 @@ uuu_version 1.2.39
 
 SDP: boot -f SPL-mfgtool.signed
 
-SDPU: delay 1000
+SDPV: delay 1000
 SDPV: write -f u-boot-mfgtool.itb
-SDPU: jump
+SDPV: jump
 
 EOF
 HASH=($(hexdump -e '/4 "0x"' -e '/4 "%X""\n"' ${FUSEBIN}))


### PR DESCRIPTION
The jump SDPU commands made the board hang, so fix it using the SDPV commands.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>