### PR TITLE
security: imx_ahab: drop removing non-existing file

### DIFF
--- a/security/imx_ahab/sign-file.sh
+++ b/security/imx_ahab/sign-file.sh
@@ -131,5 +131,4 @@ echo "Process completed successfully and signed file is ${WORK_FILE}.signed"
 # Cleanup config / mod SPL
 rm ${CSF_TEMPLATE}.csf-config
 rm -f ${CSF_TEMPLATE}.csf-config~
-rm ${WORK_FILE}_csf.bin
 rm ${WORK_FILE}.mod


### PR DESCRIPTION
Don't remove ${WORK_FILE}_csf.bin file in the end of script, as in the
current version it's not created.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>