### PR TITLE
scripts: Update the method of finding the upstream tag

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -151,7 +151,7 @@ if [ -z "${latest}" ]; then
         latest=$(git describe --tags --abbrev=0 FETCH_HEAD)
     else
         # assign last upstream prefixed tag to latest
-        latest=$(git describe --tags --abbrev=0 --match "${PREFIX}-*" FETCH_HEAD)
+        latest=$(git tag --list --sort=-version:refname "${PREFIX}-*" | head -n1)
     fi
 fi
 


### PR DESCRIPTION
The "git describe" appears to only work on the default
branch and not tags from all branches so it is necessary
to change the method of finding the latest upstream
tag to use for a partner factory lmp-manifest update.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>