### PR TITLE
Revert "security: imx8qm: replace "reboot" command"

### DIFF
--- a/security/imx8qm/gen_close.sh
+++ b/security/imx8qm/gen_close.sh
@@ -93,7 +93,7 @@ done
 echo
 cat << EOF
 FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
-FB: acmd reset
+FB: acmd reboot
 
 FB: DONE
 EOF

--- a/security/imx8qm/gen_fuse.sh
+++ b/security/imx8qm/gen_fuse.sh
@@ -93,5 +93,5 @@ do
     echo "FB: ucmd fuse prog -y ${bank} ${idx} ${HASH[$((${idx}-${OFFSET}))]}"
 done
 echo
-echo "FB: acmd reset"
+echo "FB: acmd reboot"
 echo "FB: DONE") > ${FILE}


### PR DESCRIPTION
This reverts commit e2eba455a825a8da4761755086fb38a5ae577870.

As discussed with the platform team, a "reboot" is required for a full PoR of the board, so revert this.