### PR TITLE
rotate_ci_keys: adjust kernel module signing key name

### DIFF
--- a/scripts/rotate_ci_keys.sh
+++ b/scripts/rotate_ci_keys.sh
@@ -63,7 +63,7 @@ x509_extensions = myexts
 
 [ req_distinguished_name ]
 #O = Unspecified company
-CN = Default insecure development key
+CN = Factory kernel module signing key
 #emailAddress = unspecified.user@unspecified.company
 
 [ myexts ]


### PR DESCRIPTION
This script is used to rotate CI keys which means these are not insecure development keys.  Let's not call them that as they are logged in dmesg on boot.