### PR TITLE
fixup: update-factory-manifest: bugfix for matching PREFIX when pulling tags

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -146,7 +146,7 @@ if [ -z "${PREFIX}" ]; then
     git fetch --tags --quiet ${foundries_manifest}
 else
     # only fetch tags matching PREFIX
-    git ls-remote --tags ${foundries_manifest} | cut -f2 | grep 'refs/tags/${PREFIX}' | xargs git fetch ${foundries_manifest}
+    git fetch --no-tags ${foundries_manifest} "refs/tags/${PREFIX}*:refs/tags/${PREFIX}*"
 fi
 
 


### PR DESCRIPTION
Drop complicated git ls-remote and use quotes around tag filter