### PR TITLE
uefi: support un-provisioning tool

### DIFF
--- a/security/uefi/README.txt
+++ b/security/uefi/README.txt
@@ -36,7 +36,12 @@ Provisioning the keys can be done:
       Using a custom EFI program with the certificates embedded on it.
       This should be the common way of deploying to devices.
 
-2) Sign images:
+2) Removing the provisioned keys using your own efi application:
+----------------------------------------------------------------
+Deactivating Secure Boot can be done by removing the enrolled certificates using setvar().
+To that end, we also generate the corresponding noPK.auth and noKEK.auth used to clear PK, KEK, db and dbx.
+
+3) Sign images:
 ---------------
 The DB private key must be made available to LmP during build time so that
 the bootloader and kernel image can be signed.

--- a/security/uefi/gen_uefi_certs.sh
+++ b/security/uefi/gen_uefi_certs.sh
@@ -42,5 +42,11 @@ sign-efi-sig-list -c KEK.crt -k KEK.key db DB.esl DB.auth
 sign-efi-sig-list -c KEK.crt -k KEK.key dbx DBX.esl DBX.auth
 cp PK.esl PKnoauth.auth
 
+# Generate empty AUTH files (to disable SecureBoot by removing PK,KEK and db/dbx)
+touch noKEK.esl
+sign-efi-sig-list -t "$(date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c KEK.crt -k KEK.key KEK noKEK.esl noKEK.auth
+touch noPK.esl
+sign-efi-sig-list -t "$(date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c PK.crt -k PK.key PK noPK.esl noPK.auth
+
 echo "Keys and certificates created successfully"
 echo "To sign an EFI image (bootloader/kernel): sbsign --key DB.key --cert DB.crt Image"


### PR DESCRIPTION
In order to un-provision a board, removing the certificates in operation is required.

We will follow the UEFI specification for that.