### PR TITLE
scripts/update-factory-manifest: add a second merge tentative

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -191,8 +191,18 @@ if [ "$CONFIRM" = "n" ]; then
     exit 0
 fi
 
+_git_merge_try_fix_keys(){
+    git merge --abort
+    git merge --no-commit ${latest}
+    # all of this keys are removed at factory creation so drop it all
+    git rm -f -r conf/keys
+    git commit --no-edit -m "update-manifest: merge (with conf/key conflicts) LmP ${latest}" ${latest}
+}
+
 # merge to the last upstream tag
-git merge --no-edit -m "update-manifest: merge LmP ${latest}" ${latest} || abort_merge $?
+git merge --no-edit -m "update-manifest: merge LmP ${latest}" ${latest} || \
+_git_merge_try_fix_keys || \
+abort_merge $?
 
 echo ""
 echo "Automatic update successful!"


### PR DESCRIPTION
All of the conf/keys are removed at factory creation so drop it all. The same set of keys are also created factory-keys dir at factory creation.

During the v95 development all of the uefi keys have been modified and so this would result in the following merge commit created by the script:
```
update-manifest: merge (with conf/key conflicts) LmP up/main

# Conflicts:
#       conf/keys/uefi/DB.auth
#       conf/keys/uefi/DB.cer
#       conf/keys/uefi/DB.crt
#       conf/keys/uefi/DB.esl
#       conf/keys/uefi/DB.key
#       conf/keys/uefi/DBX.auth
#       conf/keys/uefi/DBX.cer
#       conf/keys/uefi/DBX.crt
#       conf/keys/uefi/DBX.esl
#       conf/keys/uefi/DBX.key
#       conf/keys/uefi/KEK.auth
#       conf/keys/uefi/KEK.cer
#       conf/keys/uefi/KEK.crt
#       conf/keys/uefi/KEK.esl
#       conf/keys/uefi/KEK.key
#       conf/keys/uefi/PK.auth
#       conf/keys/uefi/PK.cer
#       conf/keys/uefi/PK.crt
#       conf/keys/uefi/PK.esl
#       conf/keys/uefi/PK.key
#       conf/keys/uefi/PKnoauth.auth
```